### PR TITLE
Fix minimum quorum for pipeline approval voting system

### DIFF
--- a/.github/workflows/pipeline_approval.yml
+++ b/.github/workflows/pipeline_approval.yml
@@ -63,7 +63,7 @@ jobs:
 
             const teamMembers = await getTeamMembers();
             console.log('Core and Maintainers team members:', teamMembers);
-            const quorum = Math.ceil(teamMembers.length / 2);
+            const quorum = 2;
             console.log(`Quorum set to ${quorum}.`);
 
             // Helper for list formatting and complete status body
@@ -75,7 +75,7 @@ jobs:
               const approvers = [...approvalsSet];
               const rejecters = [...rejectionsSet];
               const awaiting = awaitingArr;
-              let body = `## Pipeline approval status: ${status}\n\nPipeline has approvals from ${approvalsSet.size}/${quorum} required @core-team quorum.\n\n`;
+              let body = `## Pipeline approval status: ${status}\n\nPipeline has approvals from ${approvalsSet.size}/${quorum} required @core-team and @maintainers-team quorum.\n\n`;
               if (approvers.length > 0 || rejecters.length > 0 || awaiting.length > 0) {
                 body += `|Review&nbsp;Status|Core and Maintainer Team members|\n|--|--|\n`;
                 if (approvers.length > 0) {


### PR DESCRIPTION
We only need a max of 2 core or 1 core and 1 maintainers (not 50% of entire voting members)