### PR TITLE
Add minimum viable pipeline field to proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_pipeline.yml
+++ b/.github/ISSUE_TEMPLATE/new_pipeline.yml
@@ -36,6 +36,14 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    attributes:
+      label: What would a minimal first release of this pipeline include?
+      description: Describe the smallest useful version of this pipeline — the core steps and tools needed for a first release. Additional features can be added in later versions. E.g. for nf-core/rnaseq, an MVP would be one aligner (STAR), one quantification tool (Salmon), and base QC — additional aligners like HISAT2 and extra quantification methods would come later.
+      placeholder: "Alignment with STAR, quantification with Salmon, QC with FastQC/MultiQC. HISAT2, RSEM, and additional quantification options would come in later releases."
+    validations:
+      required: true
+
   - type: checkboxes
     attributes:
       label: "I confirm my proposed pipeline will follow nf-core guidelines. Most importantly, my pipeline will:"


### PR DESCRIPTION
## Summary
- Adds a required "What would a minimal first release of this pipeline include?" field to the new pipeline proposal issue template
- Encourages proposers to scope their first release to a minimal but functional pipeline, deferring additional features to later versions
- Uses nf-core/rnaseq as an example, consistent with the rest of the template

## Test plan
- [ ] Open a new pipeline proposal issue and verify the new field appears between the schematic diagram and the guidelines checklist
- [ ] Verify the description and placeholder text render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)