### PR TITLE
Migrate linting CI from pre-commit to prek

### DIFF
--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -31,15 +31,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
 
-      # Install and run prek (drop-in, faster pre-commit; reads the same
-      # .pre-commit-config.yaml)
+      # Run prek (drop-in, faster pre-commit; reads the same
+      # .pre-commit-config.yaml). The action runs `prek run --all-files`.
       - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
-        with:
-          install-only: true
-
-      - name: Run prek
         id: prek
-        run: prek run --all-files
         continue-on-error: true
 
       # indication that the linting has finished

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -31,22 +31,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
 
-      # Install and run pre-commit
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6
+      # Install and run prek (drop-in, faster pre-commit; reads the same
+      # .pre-commit-config.yaml)
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
         with:
-          python-version: 3.11
+          install-only: true
 
-      - name: Install pre-commit
-        run: pip install pre-commit
-
-      - name: Run pre-commit
-        id: pre-commit
-        run: pre-commit run --all-files
+      - name: Run prek
+        id: prek
+        run: prek run --all-files
         continue-on-error: true
 
       # indication that the linting has finished
       - name: react if linting finished succesfully
-        if: steps.pre-commit.outcome == 'success'
+        if: steps.prek.outcome == 'success'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ github.event.comment.id }}
@@ -54,7 +52,7 @@ jobs:
 
       - name: Commit & push changes
         id: commit-and-push
-        if: steps.pre-commit.outcome == 'failure'
+        if: steps.prek.outcome == 'failure'
         run: |
           git config user.email "core@nf-co.re"
           git config user.name "nf-core-bot"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6
-        with:
-          python-version: 3.11
-      - name: Install pre-commit
-        run: pip install pre-commit
-
-      - name: Run pre-commit
-        run: pre-commit run --all-files
+      # prek is a drop-in, faster reimplementation of pre-commit; it reads the
+      # existing .pre-commit-config.yaml and runs the same hooks.
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4


### PR DESCRIPTION
## Summary

Migrate the linting CI from [`pre-commit`](https://pre-commit.com/) to [`prek`](https://github.com/j178/prek) — a faster, single-binary, drop-in reimplementation of pre-commit written in Rust.

`prek` reads the existing `.pre-commit-config.yaml` and runs the same hooks, so the config is **kept unchanged** and contributors can still use `pre-commit` locally if they prefer. No `prek.toml`, no forced tooling change.

## Changes

- **`.github/workflows/pre-commit.yml`** — replace `actions/setup-python` + `pip install pre-commit` + `pre-commit run --all-files` with `j178/prek-action` (which runs `prek run --all-files`).
- **`.github/workflows/fix-linting.yml`** (the `@nf-core-bot fix linting` autofix) — install prek via the action (`install-only: true`) and run `prek run --all-files`, preserving the `continue-on-error` outcome that drives the commit/react logic.
- Kept the `pre-commit` job name so any required-status-check branch protection keeps matching.
- `prek-action` is pinned to a commit SHA (`v2.0.4`) to match the repo's other pinned actions.

## Why

- Faster CI and no Python bootstrap step.
- Drop-in: same `.pre-commit-config.yaml`, same hooks (prettier, editorconfig-checker, actionlint).

## Notes

- Split out of #149 (which is scoped to the proposal approval automation) so the CI tooling change can be reviewed and landed independently.
- Closes #150.

https://claude.ai/code/session_01DGsyWUGbsvfkJDgdcaYLxv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGsyWUGbsvfkJDgdcaYLxv)_